### PR TITLE
71 attach photos to all users jobs via active storage 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"
 gem "faker"
 
+gem "cloudinary"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -92,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (1.25.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -104,6 +108,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -117,6 +123,9 @@ GEM
       sassc (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -138,6 +147,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.1)
@@ -150,6 +162,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
@@ -201,6 +214,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -233,6 +251,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -264,6 +285,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
+  cloudinary
   debug
   devise
   dotenv-rails

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -3,6 +3,8 @@ class Job < ApplicationRecord
   has_many :freelancers, through: :bids
   has_many :bids
 
+  has_one_attached :photo
+
   validates :title, presence: true
   validates :description, presence: true
   validates :budget, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ApplicationRecord
   has_many :jobs, through: :bids
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  has_one_attached :photo
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,7 +8,7 @@
           results</p>
         <% @freelancers.each do |freelancer| %>
           <div class="freelancer-card d-flex pt-3">
-            <%= image_tag "https://source.unsplash.com/random" %>
+            <%= image_tag cl_image_path freelancer.photo.key %>
             <div class="freelancer-details">
               <div class="freelancer-header d-flex justify-content-between">
                 <h3><%= link_to freelancer.username, freelancer_path(freelancer) %></h3>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="d-flex justify-content-between align-items-center">
       <div class="profile-bar-content">
-        <img src="https://source.unsplash.com/random" alt="avatar" class="rounded me-3" style="width: 50px; height: 50px; object-fit: cover;">
+        <img src="<%= cl_image_path @user.photo.key %>" alt="avatar" class="rounded me-3" style="width: 50px; height: 50px; object-fit: cover;">
           <h4 class="fs-sm"><%= @user.name %></h4>
         </div>
         <a href="#" class="btn btn-primary me-2">Request quote</a>
@@ -17,7 +17,7 @@
 
     <div class="white-box d-flex justify-content-between">
       <div class="d-flex flex-column">
-        <img src="https://source.unsplash.com/random" alt="avatar" class="rounded me-2 mb-2" style="width: 250px; height: 250px; object-fit: cover;">
+        <img src="<%= cl_image_path @user.photo.key %>" alt="avatar" class="rounded me-2 mb-2" style="width: 250px; height: 250px; object-fit: cover;">
           <p><%= @user.location.split(",")[1] %></p>
           <p><%= rand(1..200) %>
             Recommendations</p>
@@ -62,7 +62,7 @@
         <ul class="list-unstyled">
           <div class="cards">
             <% @successful_bids.each do |bid| %>
-              <div class="card-category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://picsum.photos/300/180)">
+              <div class="card-category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @article.photo.key %>')">
                 <li><%= link_to bid.job.title, "#", class:"text-decoration-none text-white" %></li>
               </div>
             <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,7 +62,7 @@
         <ul class="list-unstyled">
           <div class="cards">
             <% @successful_bids.each do |bid| %>
-              <div class="card-category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path @article.photo.key %>')">
+              <div class="card-category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path bid.job.photo.key %>')">
                 <li><%= link_to bid.job.title, "#", class:"text-decoration-none text-white" %></li>
               </div>
             <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -32,3 +32,7 @@ local:
 #   service: Mirror
 #   primary: local
 #   mirrors: [ amazon, google, microsoft ]
+
+cloudinary:
+  service: Cloudinary
+  folder: <%= Rails.env %>

--- a/db/migrate/20230316073819_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230316073819_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_082648) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_073819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bids", force: :cascade do |t|
     t.integer "rate", null: false
@@ -55,6 +83,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_082648) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bids", "jobs"
   add_foreign_key "bids", "users", column: "freelancer_id"
   add_foreign_key "jobs", "users", column: "employer_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,14 +45,14 @@ Job.all.each do |job|
   end
 end
 
-User.each do |user|
+User.all.each do |user|
   file = URI.open("https://source.unsplash.com/random")
   user.photo.attach(io: file, filename: "photo#{rand(1..100)}", content_type: "image/jpg")
-  article.save
+  user.save
 end
 
-Job.each do |job|
+Job.all.each do |job|
   file = URI.open("https://source.unsplash.com/random")
   job.photo.attach(io: file, filename: "photo#{rand(1..100)}", content_type: "image/jpg")
-  article.save
+  job.save
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,3 +50,9 @@ User.each do |user|
   user.photo.attach(io: file, filename: "photo#{rand(1..100)}", content_type: "image/jpg")
   article.save
 end
+
+Job.each do |job|
+  file = URI.open("https://source.unsplash.com/random")
+  job.photo.attach(io: file, filename: "photo#{rand(1..100)}", content_type: "image/jpg")
+  article.save
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,7 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+require 'open-uri'
 
 # seeds users
 20.times do
@@ -42,4 +43,10 @@ Job.all.each do |job|
       job_id: job.id
     )
   end
+end
+
+User.each do |user|
+  file = URI.open("https://source.unsplash.com/random")
+  user.photo.attach(io: file, filename: "photo#{rand(1..100)}", content_type: "image/jpg")
+  article.save
 end


### PR DESCRIPTION
# Description

Photos on all pages were just linked to unsplashed. Seed file now attaches random photos to user and jobs, and the respective views show these attached images.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


- [x] Screenshot A
<img width="1213" alt="Screen Shot 2023-03-16 at 4 38 56 PM" src="https://user-images.githubusercontent.com/115083635/225561173-52885e11-9f67-49ff-a968-b2cc054a7ecb.png">

- [x] Screenshot B
<img width="1216" alt="Screen Shot 2023-03-16 at 4 39 05 PM" src="https://user-images.githubusercontent.com/115083635/225561186-172a5bc3-cba6-4bd3-96d5-368738438f13.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
